### PR TITLE
Adds .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.cache/
+.coverage
+*.pyc
+tests/__pycache__/*


### PR DESCRIPTION
I ran tests and was met with this:

```sh
$ gdeltPyR (master) > git status
On branch make_utility_methods_private
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.cache/
	.coverage
	gdelt/__init__.pyc
	gdelt/base.pyc
	gdelt/dateFuncs.pyc
	gdelt/getHeaders.pyc
	gdelt/helpers.pyc
	gdelt/inputChecks.pyc
	gdelt/multipdf.pyc
	gdelt/parallel.pyc
	gdelt/vectorizingFuncs.pyc
	tests/__init__.pyc
	tests/__pycache__/

nothing added to commit but untracked files present (use "git add" to track)
```

Let know me if there's anything else you'd like to add.